### PR TITLE
added preinstalledSw column for sanitizing production SKU

### DIFF
--- a/pkg/price/ec2.go
+++ b/pkg/price/ec2.go
@@ -22,6 +22,7 @@ var (
 	REQUIRED_OS             = "Linux"
 	REQUIRED_LICENSE_MODEL  = "No License required"
 	REQUIRED_USAGE          = "BoxUsage:*"
+	REQUIRED_PREINSTALLEDSW = "NA"
 
 	CACHED_PRICING = CachedEc2Pricing{}
 )
@@ -95,6 +96,7 @@ type Ec2Product struct {
 		OperatingSystem string `json:operatingSystem`
 		LicenseModel    string `json:licenseModel`
 		UsageType       string `json:usagetype`
+		PreInstalledSw  string `json:preInstalledSw`
 	}
 }
 
@@ -124,6 +126,10 @@ func (ep *Ec2Product) isValid() bool {
 	}
 
 	if ep.Attributes.Tenancy != REQUIRED_TENANCY {
+		return false
+	}
+
+	if ep.Attributes.PreInstalledSw != REQUIRED_PREINSTALLEDSW {
 		return false
 	}
 


### PR DESCRIPTION
Hi
I encountered new problems when I use it.
Actually I wanted to get a price each region, but this library worked wrong.
Finally I found out this reason.. Because of **preinstalledSW** column in JSON provided by AWS.

I'm not sure AWS added this field, **preinstalledSW** in JSON.

Anyway I added some codes to avoid duplication.
You should accept this code. It's good for this repos.

Thanks. Docker contributor. Awesome guy @odg0318 